### PR TITLE
feat: container + read-only mode + refuse silent overwrite (#11)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!px_secrets.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM python:3.11-slim AS base
+
+ARG SOPS_VERSION=3.12.1
+ARG AGE_VERSION=1.2.1
+ARG SOPS_SHA256=cf3136d20a6004405c986a48e179c3c7a731f777fbf105a37bd5dac5c9047100
+ARG AGE_SHA256=7df45a6cc87d4da11cc03a539a7470c15b1041ab2b396af088fe9990f7c79d50
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates \
+ && curl -fsSL -o /tmp/sops \
+      "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" \
+ && echo "${SOPS_SHA256}  /tmp/sops" | sha256sum -c - \
+ && install -m 0755 /tmp/sops /usr/local/bin/sops \
+ && rm /tmp/sops \
+ && curl -fsSL -o /tmp/age.tgz \
+      "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz" \
+ && echo "${AGE_SHA256}  /tmp/age.tgz" | sha256sum -c - \
+ && tar -xzf /tmp/age.tgz -C /usr/local/bin --strip-components=1 age/age age/age-keygen \
+ && chmod 0755 /usr/local/bin/age /usr/local/bin/age-keygen \
+ && rm /tmp/age.tgz \
+ && apt-get purge -y curl ca-certificates \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir flask==3.1.* pyyaml==6.0.*
+
+ENV APP_HOME=/app
+ENV HOME=${APP_HOME}
+
+RUN useradd -M -u 10001 -d ${APP_HOME} -s /usr/sbin/nologin pxs \
+ && mkdir -p ${APP_HOME}/.px-secrets ${APP_HOME}/.config/sops/age \
+ && chown -R pxs:pxs ${APP_HOME}
+
+USER pxs
+WORKDIR ${APP_HOME}
+
+COPY --chown=pxs:pxs px_secrets.py ${APP_HOME}/px_secrets.py
+
+ENV PX_SECRETS_HOST=0.0.0.0 \
+    PX_SECRETS_READ_ONLY=1 \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 9999
+
+CMD ["python3", "px_secrets.py", "--headless", "--port", "9999"]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,45 @@ This tells SOPS which key to use for encryption. Without it, adding secrets will
 
 Click **+ Add**, enter a service name (e.g., `github`), a key name (e.g., `token`), and the secret value. PX Secrets creates an encrypted vault at `~/secrets/vault.enc.yaml`.
 
+## Deploy as a service
+
+PX Secrets can also run headless as a long-lived background service — useful when scripts, agents, or other tools on the same host need to fetch secrets from the local API without you keeping a desktop session open.
+
+### Run in a container
+
+A `Dockerfile` is included in the repo. Build and run:
+
+```bash
+docker build -t px-secrets:dev .
+
+docker run -d --name px-secrets \
+  -p 127.0.0.1:9999:9999 \
+  -v /path/to/your/vault.enc.yaml:/vault/vault.enc.yaml:ro \
+  -v /path/to/your/age-key:/app/.config/sops/age/keys.txt:ro \
+  -e PX_SECRETS_HOST=0.0.0.0 \
+  -e PX_SECRETS_READ_ONLY=1 \
+  px-secrets:dev
+```
+
+The image carries no secrets — your vault file and AGE key are bind-mounted at runtime. Make sure the AGE key file is mode `0400` on the host so the runtime user (uid `10001`) can read it but nothing else can.
+
+### Environment overrides
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `PX_SECRETS_HOST` | Bind address. Set to `0.0.0.0` inside a container so port mapping works; leave unset on a workstation to keep the listener on localhost. | unset (binds to localhost) |
+| `PX_SECRETS_READ_ONLY` | When set to `1` / `true` / `yes`, the six mutating endpoints (`POST/DELETE /api/secret`, `DELETE /api/service`, `POST /api/note`, `POST /api/settings`, `POST /api/import`) return HTTP 403. Reading endpoints continue to work. Useful for daemon mode. | unset (writes allowed) |
+
+### When to use read-only mode
+
+- **Long-lived daemon** serving secrets to scripts on the same host: enable `PX_SECRETS_READ_ONLY=1`. Do edits from a separate, short-lived interactive session.
+- **Container behind a reverse proxy** with no UI auth: enable read-only at minimum; consider also fronting with an auth gateway since the API has no built-in authentication.
+- **Interactive desktop use**: leave read-only off.
+
+### Security reminder
+
+The local API is unauthenticated by design — its security boundary is the host itself. **Never expose port `9999` outside the local host or a trusted private network.** If you need remote access, front the service with an authentication layer (Authelia, oauth2-proxy, etc.) and a TLS-terminating reverse proxy.
+
 ## Usage
 
 ### GUI (default)

--- a/README.md
+++ b/README.md
@@ -334,12 +334,31 @@ We're building in public and we want your input. PX Secrets is part of [PX Open 
 - [x] About dialog with version, runtime, and system info
 - [x] Keyboard shortcuts (Cmd+K search, Escape close, Cmd+N add)
 
+**v1.5.0 — Headless / Container deployment** *(in [PR #23](../../pull/23))*
+- [ ] [Official Docker image with PX_SECRETS_HOST env](../../issues/14)
+- [ ] [Read-only mode via PX_SECRETS_READ_ONLY](../../issues/15)
+- [ ] [Deploy-as-a-service README section](../../issues/16)
+- [ ] [Refuse silent overwrite of existing secrets](../../issues/11)
+
 **Future**
+
+*Data model & UX*
+- [ ] [Nested secrets with multiple fields, multi-account services, ordered sequences](../../issues/18)
+- [ ] [Typed secrets with filter, sort, and selective import/export per type](../../issues/20)
+- [ ] [Inline edit for key_name, value, and new key_type field](../../issues/12)
+- [ ] [Multiple named vaults with per-vault access control](../../issues/21)
+
+*Security & key management*
+- [ ] [AGE key custody flow at onboarding + key rotation support](../../issues/22)
+- [ ] [Optional UI unlock layer (Touch ID / Face ID / password) with auto-lock on idle](../../issues/19)
+- [ ] [Per-secret rotation with safety confirmation](../../issues/5)
+- [ ] [2FA backup codes (TOTP recovery codes)](../../issues/13)
+- [ ] [Bearer token for multi-process hosts (discussion)](../../issues/17)
+
+*Platform & distribution*
 - [ ] [Native macOS .app bundle with custom icon (Phase 2)](../../issues/10)
 - [ ] [Onboarding wizard (first-run setup with key generation)](../../issues/2)
 - [ ] [Self-update from GitHub](../../issues/3)
-- [ ] [Per-secret rotation with safety confirmation](../../issues/5)
-- [ ] Key rotation support
 - [ ] Homebrew cask (`brew install --cask px-secrets`)
 
 See [Issues](../../issues) for the full list.

--- a/px_secrets.py
+++ b/px_secrets.py
@@ -86,6 +86,12 @@ SUPPORT_URL = "https://buymeacoffee.com/pxinnovative"
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 9999
 
+# Environment overrides for container deployment.
+# Set PX_SECRETS_HOST=0.0.0.0 to bind all interfaces (e.g. for container port mapping).
+# Set PX_SECRETS_READ_ONLY=1 to disable mutating endpoints (vault read-only mode).
+HOST_OVERRIDE = os.environ.get("PX_SECRETS_HOST")
+READ_ONLY = os.environ.get("PX_SECRETS_READ_ONLY", "").lower() in ("1", "true", "yes")
+
 # Native window dimensions (pywebview)
 NATIVE_WINDOW_WIDTH = 750
 NATIVE_WINDOW_HEIGHT = 850
@@ -194,6 +200,17 @@ def encrypt_vault(data: dict):
 app = Flask(__name__)
 
 
+def _readonly_guard():
+    """Return a 403 response tuple if PX_SECRETS_READ_ONLY env is set.
+
+    Mutating endpoints call this at entry; if the env flag is on, the request
+    is rejected before touching the vault. Returns None when writes are allowed.
+    """
+    if READ_ONLY:
+        return jsonify({"error": "Vault is read-only (PX_SECRETS_READ_ONLY=1)"}), 403
+    return None
+
+
 @app.route("/")
 def index():
     """Serve the single-page UI."""
@@ -212,15 +229,33 @@ def api_vault():
 
 @app.route("/api/secret", methods=["POST"])
 def api_add_secret():
-    """Add or update a secret in the vault."""
+    """Add or update a secret in the vault.
+
+    Refuses to overwrite an existing key unless the caller explicitly opts in
+    via `overwrite=true` (body field or query param). Silent overwrites are a
+    data-loss footgun for non-rotatable credentials like long-lived API keys.
+    """
+    guard = _readonly_guard()
+    if guard:
+        return guard
     try:
         body = request.json
         service = body["service"]
         key = body["key"]
         value = body["value"]
         note = body.get("note", "")
+        overwrite = (
+            body.get("overwrite") is True
+            or request.args.get("overwrite", "").lower() in ("1", "true", "yes")
+        )
 
         data = decrypt_vault()
+        if not overwrite and service in data and key in data[service]:
+            return jsonify({
+                "error": "Key already exists. Resend with overwrite=true to replace.",
+                "service": service,
+                "key": key,
+            }), 409
         if service not in data:
             data[service] = {}
         data[service][key] = value
@@ -235,6 +270,9 @@ def api_add_secret():
 @app.route("/api/secret", methods=["DELETE"])
 def api_delete_secret():
     """Delete a single secret (and its note) from the vault."""
+    guard = _readonly_guard()
+    if guard:
+        return guard
     try:
         body = request.json
         service = body["service"]
@@ -254,6 +292,9 @@ def api_delete_secret():
 @app.route("/api/service/<svc>", methods=["DELETE"])
 def api_delete_service(svc):
     """Delete an entire service and all its secrets from the vault."""
+    guard = _readonly_guard()
+    if guard:
+        return guard
     try:
         data = decrypt_vault()
         if svc in data:
@@ -267,6 +308,9 @@ def api_delete_service(svc):
 @app.route("/api/note", methods=["POST"])
 def api_add_note():
     """Add or update a note attached to a secret."""
+    guard = _readonly_guard()
+    if guard:
+        return guard
     try:
         body = request.json
         service = body["service"]
@@ -298,6 +342,9 @@ def api_get_settings():
 @app.route("/api/settings", methods=["POST"])
 def api_save_settings():
     """Save new vault and key configuration."""
+    guard = _readonly_guard()
+    if guard:
+        return guard
     try:
         body = request.json
         cfg = {
@@ -414,6 +461,9 @@ def api_export():
 @app.route("/api/import", methods=["POST"])
 def api_import():
     """Import secrets from .env, JSON, or YAML format."""
+    guard = _readonly_guard()
+    if guard:
+        return guard
     try:
         body = request.json
         text = body.get("text", "")
@@ -1198,7 +1248,7 @@ def main():
         return
 
     # GUI mode
-    host = DEFAULT_HOST
+    host = HOST_OVERRIDE or DEFAULT_HOST
     port = args.port
 
     # Store port in app config so /api/open-browser can read it


### PR DESCRIPTION
## Summary

Three composable improvements that together let PX Secrets run as a long-lived headless service while preserving the existing desktop experience:

- **Docker support** — `PX_SECRETS_HOST` env var so the listener can be bound to non-localhost interfaces for container port mapping, plus a minimal `Dockerfile` based on `python:3.11-slim` with pinned SOPS 3.12.1 and AGE 1.2.1 (both SHA256-verified). Runs as non-root uid 10001, exposes 9999.
- **Read-only mode** — `PX_SECRETS_READ_ONLY` env var gates the six mutating endpoints (`POST/DELETE /api/secret`, `DELETE /api/service`, `POST /api/note`, `POST /api/settings`, `POST /api/import`) behind a 403 response. Read endpoints continue to work. Useful for daemons that should serve secrets to scripts but never accept writes from them.
- **Refuse silent overwrite (#11)** — `POST /api/secret` now returns 409 Conflict if the `(service, key)` already exists, unless the caller opts in with `overwrite=true` (body field or query param). Prevents silent data loss for non-rotatable credentials like long-lived API keys.

All three are **opt-in and backward compatible**. With env vars unset and no `overwrite=true` flag, prior behaviour is preserved (modulo the 409 which is the desired stricter default — old callers that overwrote unknowingly now learn they were overwriting).

The README gains a new "Deploy as a service" section showing the container workflow, env vars, and a security reminder that the API is unauthenticated by design and port 9999 must never be exposed beyond the local host.

## Closes
- Closes #11 (silent overwrite)
- Closes #14 (Docker image)
- Closes #15 (read-only env)
- Closes #16 (README deploy docs)

## Test plan
- [x] `python3 -m py_compile px_secrets.py` passes
- [x] Image builds (`docker buildx build --platform linux/amd64 .`) — 71 MiB
- [x] Container starts, `GET /api/about` and `GET /api/vault` return 200
- [x] `POST /api/secret` returns 403 when `PX_SECRETS_READ_ONLY=1`
- [x] `POST /api/secret` to existing key returns 409 without `overwrite=true`, 200 with it
- [x] Image carries no secrets (`.dockerignore` excludes everything except `px_secrets.py`)
- [ ] CI workflow (if added later) green
- [ ] README example commands smoke-tested by a fresh user

## Out of scope
- Issues #17 (token auth discussion), #18-22 (nested secrets, UI lock, typed secrets, multi-vault, AGE key custody) — separate PRs.
- UI handling of 409 responses for existing-key conflict — the API contract is set; UI can land its prompt in a follow-up PR (small change in the embedded HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)