### PR TITLE
chore(release): v1.5.1 — UI casing honesty + version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,14 +334,15 @@ We're building in public and we want your input. PX Secrets is part of [PX Open 
 - [x] About dialog with version, runtime, and system info
 - [x] Keyboard shortcuts (Cmd+K search, Escape close, Cmd+N add)
 
-**v1.5.0 — Headless / Container deployment** *(merged, release pending)*
+**v1.5.0 — Headless / Container deployment** *(shipped in v1.5.1 release)*
 - [x] [Official Docker image with PX_SECRETS_HOST env](../../issues/14)
 - [x] [Read-only mode via PX_SECRETS_READ_ONLY](../../issues/15)
 - [x] [Deploy-as-a-service README section](../../issues/16)
 - [x] [Refuse silent overwrite of existing secrets](../../issues/11)
 
-**v1.5.1 — Data integrity fixes** *(merged, release pending)*
+**v1.5.1 — Data integrity and UI honesty**
 - [x] [Case-insensitive service dedup on add/delete/note/import](../../issues/24)
+- [x] Service names render with their stored casing — the UI no longer force-uppercases display, so what you see in the list matches exactly what was saved
 
 **Future**
 

--- a/px_secrets.py
+++ b/px_secrets.py
@@ -78,7 +78,7 @@ def _configure_macos_identity(headless=False):
 # ---------------------------------------------------------------------------
 
 APP_NAME = "PX Secrets"
-VERSION = "1.4.1"
+VERSION = "1.5.1"
 REPO_URL = "https://github.com/pxinnovative/px-secrets"
 SUPPORT_URL = "https://buymeacoffee.com/pxinnovative"
 
@@ -607,7 +607,7 @@ h1{font-size:22px;font-weight:600;color:var(--accent)}
 .card-header:hover{background:#2a2a2a}
 .arrow{color:var(--muted);font-size:10px;transition:transform .2s;width:12px;text-align:center}
 .arrow.open{transform:rotate(90deg)}
-.svc-name{color:var(--accent);font-weight:600;font-size:15px;text-transform:uppercase;letter-spacing:.5px}
+.svc-name{color:var(--accent);font-weight:600;font-size:15px}
 .key-count{color:var(--muted);font-size:13px;margin-left:auto}
 .card-body{display:none;padding:4px 12px 10px}
 .card-body.open{display:block}


### PR DESCRIPTION
Release prep for v1.5.1.

## Code changes

- **UI casing honesty** — removes `text-transform:uppercase` from `.svc-name`. Service names now render with their stored casing, so `oMLX` shows as `oMLX` (not `OMLX`), `AdGuard` shows as `AdGuard` (not `ADGUARD`). Removes a visual lie that also helped obscure the case-duplicate bug fixed in PR #25 — when both `Test` and `test` existed they used to render identically as `TEST`.
- **Version bump** — VERSION constant goes from 1.4.1 to 1.5.1.

## README

Consolidates the v1.5.0 and v1.5.1 roadmap sections. Both feature batches (container deployment from PR #23 + case-dedup from PR #25 + this UI fix) ship together as the v1.5.1 release tag.

## After merge

Tag `v1.5.1` will be cut at the merge commit and published with full release notes covering all three PRs (#23, #25, this one).