### PR TITLE
fix(v1.6.1): /healthz + /readyz exempt from bearer auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,9 @@ We're building in public and we want your input. PX Secrets is part of [PX Open 
 - [x] [Self-update from the GitHub Releases API](../../issues/3) — `Check for updates` button in the About dialog, single-file replacement, backup-on-rollback, process restart via LaunchAgent / systemd `KeepAlive`
 - [x] [Bearer token authentication for `/api/*` via `PX_SECRETS_AUTH_TOKEN`](../../issues/17) — unblocks safe API exposure for non-human callers on multi-process hosts; UI prompts on 401 and caches the token in sessionStorage
 
+**v1.6.1 — Auth-exempt health endpoints**
+- [x] Adds `/healthz` (liveness) and `/readyz` (readiness, exercises the SOPS+AGE decrypt chain) outside the `/api/` prefix so Kubernetes / systemd probes don't 401 when `PX_SECRETS_AUTH_TOKEN` is set
+
 **Future**
 
 *Data model & UX*

--- a/px_secrets.py
+++ b/px_secrets.py
@@ -78,7 +78,7 @@ def _configure_macos_identity(headless=False):
 # ---------------------------------------------------------------------------
 
 APP_NAME = "PX Secrets"
-VERSION = "1.6.0"
+VERSION = "1.6.1"
 REPO_URL = "https://github.com/pxinnovative/px-secrets"
 SUPPORT_URL = "https://buymeacoffee.com/pxinnovative"
 GITHUB_API_BASE = "https://api.github.com/repos/pxinnovative/px-secrets"
@@ -267,6 +267,31 @@ def _resolve_service_case(service: str, data: dict) -> str:
 def index():
     """Serve the single-page UI."""
     return HTML_PAGE
+
+
+@app.route("/healthz")
+def healthz():
+    """Liveness probe — deliberately outside the /api/ prefix so the bearer-token
+    guard exempts it. Returns 200 if the process is alive; does not touch the
+    vault. Use this from Kubernetes / systemd liveness probes when
+    PX_SECRETS_AUTH_TOKEN is set, otherwise the probe would 401 and the
+    supervisor would kill a healthy pod.
+    """
+    return jsonify({"status": "ok", "version": VERSION})
+
+
+@app.route("/readyz")
+def readyz():
+    """Readiness probe — exercises the full SOPS+AGE decrypt chain so a 200
+    means everything the pod needs (vault mount, AGE key, sops binary, yaml
+    parser) is wired up correctly. Returns 500 with the failure reason
+    otherwise. Also auth-exempt by virtue of being outside /api/.
+    """
+    try:
+        decrypt_vault()
+        return jsonify({"status": "ready"})
+    except Exception as e:
+        return jsonify({"status": "not-ready", "error": str(e)}), 500
 
 
 @app.route("/api/vault")


### PR DESCRIPTION
Patch v1.6.1 closes the regression introduced by v1.6.0 PX_SECRETS_AUTH_TOKEN — Kubernetes liveness probes pointed at `/api/about` get 401'd and the pod is killed.

## Changes

- New `/healthz` endpoint — returns `{status:ok, version}`. Pure liveness, no vault touch.
- New `/readyz` endpoint — exercises `decrypt_vault()` and returns 200 only if the full SOPS+AGE chain works.
- Both endpoints live outside the `/api/` prefix so the `before_request` auth guard exempts them naturally.

## Migration

If you set `PX_SECRETS_AUTH_TOKEN`: update your K8s probes (or equivalent) from `/api/about` → `/healthz` and `/api/vault` → `/readyz`. Deployments without AUTH_TOKEN can keep their existing probes.