### PR TITLE
fix(v1.6.2): remove PX_SECRETS_READ_ONLY=1 from Dockerfile default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,16 @@ WORKDIR ${APP_HOME}
 COPY --chown=pxs:pxs px_secrets.py ${APP_HOME}/px_secrets.py
 
 ENV PX_SECRETS_HOST=0.0.0.0 \
-    PX_SECRETS_READ_ONLY=1 \
     PYTHONUNBUFFERED=1
+
+# Note: PX_SECRETS_READ_ONLY is deliberately NOT set here. Security policy
+# (read-only vs. read-write) is a deployment-layer concern, not an image
+# concern. Set `-e PX_SECRETS_READ_ONLY=1` at `docker run` / K8s manifest
+# level for a read-only sidecar; leave unset for writable. Setting it as
+# a Dockerfile default would make it impossible to deploy a writable pod
+# without explicitly overriding to empty in the manifest — a footgun for
+# Olares-as-source-of-truth deployments where the pod IS the authoritative
+# writer.
 
 EXPOSE 9999
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,9 @@ We're building in public and we want your input. PX Secrets is part of [PX Open 
 **v1.6.1 — Auth-exempt health endpoints**
 - [x] Adds `/healthz` (liveness) and `/readyz` (readiness, exercises the SOPS+AGE decrypt chain) outside the `/api/` prefix so Kubernetes / systemd probes don't 401 when `PX_SECRETS_AUTH_TOKEN` is set
 
+**v1.6.2 — Dockerfile no longer hard-codes read-only mode**
+- [x] `PX_SECRETS_READ_ONLY` removed as a Dockerfile `ENV` default — security policy is a deployment concern, not an image concern. Writable is the default; pass `-e PX_SECRETS_READ_ONLY=1` (or set in the K8s manifest) when you want a read-only sidecar. Previously the bake-in made it impossible to deploy a writable pod without an explicit override-to-empty in every manifest.
+
 **Future**
 
 *Data model & UX*

--- a/px_secrets.py
+++ b/px_secrets.py
@@ -78,7 +78,7 @@ def _configure_macos_identity(headless=False):
 # ---------------------------------------------------------------------------
 
 APP_NAME = "PX Secrets"
-VERSION = "1.6.1"
+VERSION = "1.6.2"
 REPO_URL = "https://github.com/pxinnovative/px-secrets"
 SUPPORT_URL = "https://buymeacoffee.com/pxinnovative"
 GITHUB_API_BASE = "https://api.github.com/repos/pxinnovative/px-secrets"


### PR DESCRIPTION
Security policy belongs in the deployment, not in the image. Baking READ_ONLY=1 as a Dockerfile ENV default made it impossible to deploy a writable pod without explicitly overriding to empty string in every manifest — a footgun for source-of-truth deployments.

The README 'Deploy as a service' section already documents `-e PX_SECRETS_READ_ONLY=1` as the opt-in for read-only sidecars, so removing the default is consistent with documented usage.

**New default**: writable. Opt-in to read-only by setting the env var at `docker run` time or in your K8s manifest.